### PR TITLE
Fix PHP Warning

### DIFF
--- a/express_checkout/ajax.php
+++ b/express_checkout/ajax.php
@@ -25,7 +25,7 @@
  */
 
 include_once dirname(__FILE__).'/../../../config/config.inc.php';
-include_once _PS_ROOT_DIR_.'init.php';
+include_once _PS_ROOT_DIR_.'/init.php';
 include_once dirname(__FILE__).'/../paypal.php';
 
 // Ajax query


### PR DESCRIPTION
Missing slash on include clause causes PHP Warnings
