### PR TITLE
hookHeader require 1 argument

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -645,9 +645,9 @@ class PayPal extends PaymentModule
         return true;
     }
 
-    public function hookDisplayMobileHeader()
+    public function hookDisplayMobileHeader($params = null)
     {
-        return $this->hookHeader();
+        return $this->hookHeader($params);
     }
 
     public function hookDisplayMobileShoppingCartTop()


### PR DESCRIPTION
Fix PHP Warning:  Missing argument 1 for PayPal::hookHeader(), called in modules/paypal/paypal.php on line 650
